### PR TITLE
Fix README link to exif.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I used the amazing [create-react-app](https://github.com/facebookincubator/creat
 
 First, there's a symlink to a folder of images which is ignored by git. For me, this folder lives in Dropbox, so I can keep it in sync across my computers and server.
 
-Next, there's the pre-start script [`exif.js`](https://github.com/daneden/photos.daneden.me/blob/master/src/runtime/exif.js). This Node script uses `node-exiftool` to loop over each image in the folder and extract exif data. The particular data I wanted to display was the aperture, shutter speed, ISO, and focal length. This data is dropped into `manifest.js`, which is again ignored by git.
+Next, there's the pre-start script [`exif.js`](https://github.com/daneden/photos.daneden.me/blob/master/scripts/exif.js). This Node script uses `node-exiftool` to loop over each image in the folder and extract exif data. The particular data I wanted to display was the aperture, shutter speed, ISO, and focal length. This data is dropped into `manifest.js`, which is again ignored by git.
 
 [`index.js`](https://github.com/daneden/photos.daneden.me/blob/master/src/index.js) is what imports the data from `manifest.js` and passes it as props to the images, which are rendered as React components.
 


### PR DESCRIPTION
Current link is broken, just a small fix after https://github.com/daneden/photos.daneden.me/commit/698742d46f442c6e2fcd35dee4634b51953afbbb.

(Btw, link in last paragraph is broken too)